### PR TITLE
Fix requiretty issue with devstack, reduce distros to CentOS 6.5

### DIFF
--- a/devstack.template
+++ b/devstack.template
@@ -20,13 +20,10 @@ parameters:
   image:
     type: string
     description: Server image id to use
-    default: Ubuntu 12.04 LTS (Precise Pangolin)
+    default: CentOS 6.5
     constraints:
     - allowed_values:
       - CentOS 6.5
-      - Red Hat Enterprise Linux 6.4
-      - Ubuntu 12.04 LTS (Precise Pangolin)
-      - Fedora 18 (Spherical Cow)
       description: must be a Devstack-supported distro
 
   server_name:


### PR DESCRIPTION
The stack.sh script gets run, but there's another weird issue to work out.  SSH is not responsive once the stack is in CREATE_COMPLETE.

The following is from /var/log/cloud-init-output.log.  See the part about ssh-authkey-fingerprints failing. 

```
2014-03-13 21:12:17,330 - stages.py[WARNING]: Module ca-certs is verified on ['debian', 'ubuntu'] distros but not on rhel distro. It may or may not work correctly.
Cloud-init v. 0.7.5 running 'modules:config' at Thu, 13 Mar 2014 21:12:17 +0000. Up 39.41 seconds.
2014-03-13 21:12:18,199 - stages.py[WARNING]: Module emit_upstart is verified on ['debian', 'ubuntu'] distros but not on rhel distro. It may or may not work correctly.
2014-03-13 21:12:18,217 - stages.py[WARNING]: Module ssh-import-id is verified on ['ubuntu'] distros but not on rhel distro. It may or may not work correctly.
2014-03-13 21:12:18,219 - stages.py[WARNING]: Module grub-dpkg is verified on ['debian', 'ubuntu'] distros but not on rhel distro. It may or may not work correctly.
2014-03-13 21:12:18,220 - stages.py[WARNING]: Module apt-pipelining is verified on ['debian', 'ubuntu'] distros but not on rhel distro. It may or may not work correctly.
2014-03-13 21:12:18,221 - stages.py[WARNING]: Module apt-configure is verified on ['debian', 'ubuntu'] distros but not on rhel distro. It may or may not work correctly.
2014-03-13 21:12:18,223 - stages.py[WARNING]: Module landscape is verified on ['ubuntu'] distros but not on rhel distro. It may or may not work correctly.
2014-03-13 21:12:18,228 - stages.py[WARNING]: Module byobu is verified on ['debian', 'ubuntu'] distros but not on rhel distro. It may or may not work correctly.
Cloud-init v. 0.7.5 running 'modules:final' at Thu, 13 Mar 2014 21:12:18 +0000. Up 40.31 seconds.
2014-03-13 21:12:19,078 - util.py[WARNING]: Running ssh-authkey-fingerprints (<module 'cloudinit.config.cc_ssh_authkey_fingerprints' from '/usr/lib/python2.6/site-packages/cloudinit/config/cc_ssh_authkey_fingerprints.pyc'>) failed
Cloud-init v. 0.7.5 finished at Thu, 13 Mar 2014 21:12:19 +0000. Datasource DataSourceConfigDriveNet [net,ver=2][source=/dev/xvdd].  Up 41.04 seconds
```

Seems to be a bug in cloud-init:
https://bugs.launchpad.net/ubuntu/+source/cloud-init/+bug/1073204
