### PR TITLE
Fix devstack template

### DIFF
--- a/devstack.template
+++ b/devstack.template
@@ -133,9 +133,9 @@ resources:
             # Install requirements
             packages="git emacs nmap"
             if apt-get update; then
-                apt-get install -y $packages
+              apt-get install -y $packages
             else
-                yum -y install $packages
+              yum -y install $packages
             fi
 
             # Configure and install Devstack
@@ -151,19 +151,19 @@ resources:
             git clone git://github.com/openstack-dev/devstack.git -b "%devstack_branch%"
             cd devstack
             if [[ "%enable_heat%" == "true" ]]; then
-                echo "enable_service heat h-api h-api-cfn h-api-cw h-eng" > localrc
+              echo "enable_service heat h-api h-api-cfn h-api-cw h-eng" > localrc
             fi
             if [[ -n "%admin_pass%" ]]; then
-                echo "ADMIN_PASSWORD=%admin_pass%" >> localrc
+              echo "ADMIN_PASSWORD=%admin_pass%" >> localrc
             fi
             if [[ -n "%mysql_pass%" ]]; then
-                echo "MYSQL_PASSWORD=%mysql_pass%" >> localrc
+              echo "MYSQL_PASSWORD=%mysql_pass%" >> localrc
             fi
             if [[ -n "%rabbit_pass%" ]]; then
-                echo "RABBIT_PASSWORD=%rabbit_pass%" >> localrc
+              echo "RABBIT_PASSWORD=%rabbit_pass%" >> localrc
             fi
             if [[ -n "%service_pass%" ]]; then
-                echo "SERVICE_PASSWORD=%service_pass%" >> localrc
+              echo "SERVICE_PASSWORD=%service_pass%" >> localrc
             fi
             echo "SERVICE_TOKEN=$(openssl rand -hex 10)" >> localrc
 


### PR DESCRIPTION
It works 100% of the time now on Ubuntu and CentOS.  CentOS will take
~20 mintues to finish, during which SSH will not be responsive.

I will work with the images team and try to get lines 120-131 out of the template.
